### PR TITLE
chore: update package-lock.json with missing license field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -968,6 +968,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.0.1.tgz",
       "integrity": "sha512-4V9fHbHjcx9Qu4O99AM5B4zuEDfB4zajk1I77hEzOxPN00f8g3484Aeq6WpfFcmookvjLE3Pr71Dhf/lqw7tbA==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.0.1"
       },


### PR DESCRIPTION
The license field was added to @fortawesome/free-regular-svg-icons dependency to properly document its licensing terms (CC-BY-4.0 AND MIT).